### PR TITLE
CRUD user

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 # Keep environment variables out of version control
 .env
 .idea
+dist

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,11 @@
       "dependencies": {
         "@nestjs/common": "^8.0.0",
         "@nestjs/core": "^8.0.0",
+        "@nestjs/mapped-types": "^1.0.0",
         "@nestjs/platform-express": "^8.0.0",
         "@prisma/client": "^2.30.2",
+        "class-transformer": "^0.4.0",
+        "class-validator": "^0.13.1",
         "reflect-metadata": "^0.1.13",
         "rimraf": "^3.0.2",
         "rxjs": "^7.2.0"
@@ -1604,6 +1607,17 @@
         }
       }
     },
+    "node_modules/@nestjs/mapped-types": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-1.0.0.tgz",
+      "integrity": "sha512-26AW5jHadLXtvHs+M+Agd9KZ92dDlBrmD0rORlBlvn2KvsWs4JRaKl2mUsrW7YsdZeAu3Hc4ukqyYyDdyCmMWQ==",
+      "peerDependencies": {
+        "@nestjs/common": "^7.0.8 || ^8.0.0",
+        "class-transformer": "^0.2.0 || ^0.3.0 || ^0.4.0",
+        "class-validator": "^0.11.1 || ^0.12.0 || ^0.13.0",
+        "reflect-metadata": "^0.1.12"
+      }
+    },
     "node_modules/@nestjs/platform-express": {
       "version": "8.0.6",
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-8.0.6.tgz",
@@ -2183,6 +2197,11 @@
       "dependencies": {
         "@types/superagent": "*"
       }
+    },
+    "node_modules/@types/validator": {
+      "version": "13.6.3",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.6.3.tgz",
+      "integrity": "sha512-fWG42pMJOL4jKsDDZZREnXLjc3UE0R8LOJfARWYg6U966rxDT7TYejYzLnUF5cvSObGg34nd0+H2wHHU5Omdfw=="
     },
     "node_modules/@types/yargs": {
       "version": "16.0.4",
@@ -3213,6 +3232,21 @@
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
       "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
       "dev": true
+    },
+    "node_modules/class-transformer": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.4.0.tgz",
+      "integrity": "sha512-ETWD/H2TbWbKEi7m9N4Km5+cw1hNcqJSxlSYhsLsNjQzWWiZIYA1zafxpK9PwVfaZ6AqR5rrjPVUBGESm5tQUA=="
+    },
+    "node_modules/class-validator": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.13.1.tgz",
+      "integrity": "sha512-zWIeYFhUitvAHBwNhDdCRK09hWx+P0HUwFE8US8/CxFpMVzkUK8RJl7yOIE+BVu2lxyPNgeOaFv78tLE47jBIg==",
+      "dependencies": {
+        "@types/validator": "^13.1.3",
+        "libphonenumber-js": "^1.9.7",
+        "validator": "^13.5.2"
+      }
     },
     "node_modules/cli-cursor": {
       "version": "3.1.0",
@@ -6742,6 +6776,11 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/libphonenumber-js": {
+      "version": "1.9.25",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.9.25.tgz",
+      "integrity": "sha512-LsSjcmXXGujESsrOsF2rrLdmuABj3OluCzPJKVNslJ2qc7xF5KdKXN8y0OcxHVurqosVf1/r4itrVrKSrlbVHA=="
+    },
     "node_modules/lines-and-columns": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
@@ -9163,6 +9202,14 @@
         "node": ">=10.12.0"
       }
     },
+    "node_modules/validator": {
+      "version": "13.6.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.6.0.tgz",
+      "integrity": "sha512-gVgKbdbHgtxpRyR8K0O6oFZPhhB5tT1jeEHZR0Znr9Svg03U0+r9DXWMrnRAB+HtCStDQKlaIZm42tVsVjqtjg==",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -10871,6 +10918,12 @@
         "uuid": "8.3.2"
       }
     },
+    "@nestjs/mapped-types": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-1.0.0.tgz",
+      "integrity": "sha512-26AW5jHadLXtvHs+M+Agd9KZ92dDlBrmD0rORlBlvn2KvsWs4JRaKl2mUsrW7YsdZeAu3Hc4ukqyYyDdyCmMWQ==",
+      "requires": {}
+    },
     "@nestjs/platform-express": {
       "version": "8.0.6",
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-8.0.6.tgz",
@@ -11350,6 +11403,11 @@
       "requires": {
         "@types/superagent": "*"
       }
+    },
+    "@types/validator": {
+      "version": "13.6.3",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.6.3.tgz",
+      "integrity": "sha512-fWG42pMJOL4jKsDDZZREnXLjc3UE0R8LOJfARWYg6U966rxDT7TYejYzLnUF5cvSObGg34nd0+H2wHHU5Omdfw=="
     },
     "@types/yargs": {
       "version": "16.0.4",
@@ -12122,6 +12180,21 @@
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
       "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
       "dev": true
+    },
+    "class-transformer": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.4.0.tgz",
+      "integrity": "sha512-ETWD/H2TbWbKEi7m9N4Km5+cw1hNcqJSxlSYhsLsNjQzWWiZIYA1zafxpK9PwVfaZ6AqR5rrjPVUBGESm5tQUA=="
+    },
+    "class-validator": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.13.1.tgz",
+      "integrity": "sha512-zWIeYFhUitvAHBwNhDdCRK09hWx+P0HUwFE8US8/CxFpMVzkUK8RJl7yOIE+BVu2lxyPNgeOaFv78tLE47jBIg==",
+      "requires": {
+        "@types/validator": "^13.1.3",
+        "libphonenumber-js": "^1.9.7",
+        "validator": "^13.5.2"
+      }
     },
     "cli-cursor": {
       "version": "3.1.0",
@@ -14823,6 +14896,11 @@
         "type-check": "~0.4.0"
       }
     },
+    "libphonenumber-js": {
+      "version": "1.9.25",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.9.25.tgz",
+      "integrity": "sha512-LsSjcmXXGujESsrOsF2rrLdmuABj3OluCzPJKVNslJ2qc7xF5KdKXN8y0OcxHVurqosVf1/r4itrVrKSrlbVHA=="
+    },
     "lines-and-columns": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
@@ -16610,6 +16688,11 @@
         "convert-source-map": "^1.6.0",
         "source-map": "^0.7.3"
       }
+    },
+    "validator": {
+      "version": "13.6.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.6.0.tgz",
+      "integrity": "sha512-gVgKbdbHgtxpRyR8K0O6oFZPhhB5tT1jeEHZR0Znr9Svg03U0+r9DXWMrnRAB+HtCStDQKlaIZm42tVsVjqtjg=="
     },
     "vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -23,8 +23,11 @@
   "dependencies": {
     "@nestjs/common": "^8.0.0",
     "@nestjs/core": "^8.0.0",
+    "@nestjs/mapped-types": "^1.0.0",
     "@nestjs/platform-express": "^8.0.0",
     "@prisma/client": "^2.30.2",
+    "class-transformer": "^0.4.0",
+    "class-validator": "^0.13.1",
     "reflect-metadata": "^0.1.13",
     "rimraf": "^3.0.2",
     "rxjs": "^7.2.0"

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,5 +1,4 @@
 import { Controller, Get } from '@nestjs/common';
-import { userInfo } from 'os';
 import { AppService } from './app.service';
 
 @Controller()

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,9 +1,10 @@
 import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { UserModule } from './modules/user/user.module';
 
 @Module({
-  imports: [],
+  imports: [UserModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/src/filters/all-exceptions.filter.ts
+++ b/src/filters/all-exceptions.filter.ts
@@ -1,0 +1,13 @@
+import { ArgumentsHost, Catch, NotFoundException } from '@nestjs/common';
+import { BaseExceptionFilter } from '@nestjs/core';
+
+@Catch()
+export class AllExceptionsFilter extends BaseExceptionFilter {
+  catch(exception: any, host: ArgumentsHost) {
+    if ('name' in exception && exception.name === 'NotFoundError') {
+      return super.catch(new NotFoundException('Resource not found'), host);
+    }
+
+    super.catch(exception, host);
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,21 @@
-import { NestFactory } from '@nestjs/core';
+import { HttpStatus, ValidationPipe } from '@nestjs/common';
+import { HttpAdapterHost, NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
+import { AllExceptionsFilter } from './filters/all-exceptions.filter';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  app.useGlobalPipes(
+    new ValidationPipe({
+      transform: true,
+      stopAtFirstError: true,
+      errorHttpStatusCode: HttpStatus.UNPROCESSABLE_ENTITY,
+      whitelist: true,
+    }),
+  );
+  app.setGlobalPrefix('api');
+  const { httpAdapter } = app.get(HttpAdapterHost);
+  app.useGlobalFilters(new AllExceptionsFilter(httpAdapter));
   await app.listen(3000);
 }
 bootstrap();

--- a/src/modules/prisma/prisma.module.ts
+++ b/src/modules/prisma/prisma.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { PrismaService } from './prisma.service';
+
+@Module({
+  providers: [PrismaService],
+  exports: [PrismaService],
+})
+export class PrismaModule {}

--- a/src/modules/prisma/prisma.service.ts
+++ b/src/modules/prisma/prisma.service.ts
@@ -1,0 +1,20 @@
+import { INestApplication, Injectable, OnModuleInit } from '@nestjs/common';
+import { PrismaClient } from '@prisma/client';
+
+@Injectable()
+export class PrismaService extends PrismaClient implements OnModuleInit {
+  constructor() {
+    super({
+      log: ['query', 'info', 'warn', 'error'],
+    });
+  }
+  async onModuleInit() {
+    await this.$connect();
+  }
+
+  async enableShutdownHooks(app: INestApplication) {
+    this.$on('beforeExit', async () => {
+      await app.close();
+    });
+  }
+}

--- a/src/modules/user/dto/create-user.dto.ts
+++ b/src/modules/user/dto/create-user.dto.ts
@@ -1,0 +1,29 @@
+import {
+  IsEmail,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  MaxLength,
+  MinLength,
+} from 'class-validator';
+
+export class CreateUserDto {
+  @IsEmail()
+  @MinLength(5)
+  @MaxLength(255)
+  @IsString()
+  @IsNotEmpty()
+  email: string;
+
+  @MinLength(5)
+  @MaxLength(255)
+  @IsString()
+  @IsNotEmpty()
+  name: string;
+
+  @MinLength(5)
+  @MaxLength(255)
+  @IsString()
+  @IsOptional()
+  nickname?: string;
+}

--- a/src/modules/user/dto/update-user.dto.ts
+++ b/src/modules/user/dto/update-user.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateUserDto } from './create-user.dto';
+
+export class UpdateUserDto extends PartialType(CreateUserDto) {}

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -1,0 +1,48 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  ParseIntPipe,
+  Post,
+  Put,
+} from '@nestjs/common';
+import { CreateUserDto } from './dto/create-user.dto';
+import { UpdateUserDto } from './dto/update-user.dto';
+import { UserService } from './user.service';
+
+@Controller('users')
+export class UserController {
+  constructor(private userService: UserService) {}
+  @Get()
+  index() {
+    return this.userService.findAll();
+  }
+
+  @Post()
+  create(@Body() createUser: CreateUserDto) {
+    return this.userService.create(createUser);
+  }
+
+  @Put(':id')
+  update(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() updateUser: UpdateUserDto,
+  ) {
+    return this.userService.update(id, updateUser);
+  }
+
+  @Get(':id')
+  show(@Param('id', ParseIntPipe) id: number) {
+    return this.userService.show(id);
+  }
+
+  @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  delete(@Param('id', ParseIntPipe) id: number) {
+    return this.userService.delete(id);
+  }
+}

--- a/src/modules/user/user.module.ts
+++ b/src/modules/user/user.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { PrismaModule } from '../prisma/prisma.module';
+import { UserController } from './user.controller';
+import { UserService } from './user.service';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [UserController],
+  providers: [UserService],
+})
+export class UserModule {}

--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -1,0 +1,75 @@
+import { Injectable, UnprocessableEntityException } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
+import { CreateUserDto } from './dto/create-user.dto';
+import { UpdateUserDto } from './dto/update-user.dto';
+
+@Injectable()
+export class UserService {
+  constructor(private prismaService: PrismaService) {}
+  async findAll() {
+    return await this.prismaService.user.findMany();
+  }
+
+  async create(createUser: CreateUserDto) {
+    const existUser = await this.prismaService.user.findFirst({
+      where: { email: createUser.email },
+    });
+
+    if (existUser) {
+      throw new UnprocessableEntityException('Email is already exist.');
+    }
+
+    const userPayload: Prisma.UserCreateInput = {
+      email: createUser.email,
+      name: createUser.name,
+      profile: {
+        create: {
+          nickname: createUser.nickname,
+        },
+      },
+    };
+
+    return this.prismaService.user.create({ data: userPayload });
+  }
+
+  async update(userId: number, updateUser: UpdateUserDto) {
+    await this.prismaService.user.findUnique({
+      select: { id: true },
+      where: { id: userId },
+      rejectOnNotFound: true,
+    });
+
+    const email = updateUser.email;
+    if (email) {
+      const existUser = await this.prismaService.user.findFirst({
+        where: {
+          email: email,
+          id: {
+            not: userId,
+          },
+        },
+      });
+
+      if (existUser) {
+        throw new UnprocessableEntityException('Email is already exist.');
+      }
+    }
+
+    return this.prismaService.user.update({
+      where: { id: userId },
+      data: { email: updateUser.email, name: updateUser.name },
+    });
+  }
+
+  show(userId: number) {
+    return this.prismaService.user.findUnique({
+      where: { id: userId },
+      rejectOnNotFound: true,
+    });
+  }
+
+  delete(userId: number) {
+    return this.prismaService.user.delete({ where: { id: userId } });
+  }
+}


### PR DESCRIPTION
- Prisma doesn't automatically trip field that doesn't exist in database but in DTO object
```
[Nest] 89398  - 09/03/2021, 3:28:32 PM   ERROR [ExceptionsHandler] 
Invalid `prisma.user.create()` invocation:

{
  data: {
    email: 'linh@gmail.com',
    name: 'Linh Pham',
    nickname: 'Nick name',
    ~~~~~~~~
    profile: {
      create: {
        nickname: 'Nick name'
      }
    }
  }
}

Unknown arg `nickname` in data.nickname for type UserCreateInput. Did you mean `name`? Available args:
type UserCreateInput {
  email: String
  name: String
  createdAt?: DateTime
  updatedAt?: DateTime
  posts?: PostCreateNestedManyWithoutAuthorInput
  profile: ProfileCreateNestedOneWithoutUserInput
}
```
- Handle exception
 ```ts
if ('name' in exception && exception.name === 'NotFoundError') {
      return super.catch(new NotFoundException('Resource not found'), host);
}
 ```
- Type will generate by Prisma. Such as: `Prisma.UserCreateInput`
```ts
const userPayload: Prisma.UserCreateInput = {
  email: createUser.email,
  name: createUser.name,
  profile: {
    create: {
      nickname: createUser.nickname,
    },
  },
};
```